### PR TITLE
Make the lobby counters monospace

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1710,7 +1710,7 @@ a.post_link.text:hover {
     flex-direction: row !important;
     align-items: center !important;
     justify-content: center !important;
-    font-family: monospace !important;
+    font-family: 'Roboto Mono', monospace !important;
 }
 
 #nb_connected_players {

--- a/styles.css
+++ b/styles.css
@@ -1710,6 +1710,7 @@ a.post_link.text:hover {
     flex-direction: row !important;
     align-items: center !important;
     justify-content: center !important;
+    font-family: monospace !important;
 }
 
 #nb_connected_players {


### PR DESCRIPTION
Right now the lobby counters are not monospaced so they jitter back and forth when they are updated. Making them monospaced removes this issue.