### PR TITLE
feat: add import export to firefox

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -45,6 +45,11 @@
         <button id="resetButton">
             Reset to Defaults
         </button>
+
+        <div id="basicImportExportContainer" style="display:none;">
+            <textarea rows="10" id="basicImportExport"></textarea>
+            <div class="button" id="importExportAction">SaveOrCopy</div>
+        </div>
     </form>
     <script src="https://cdn.jsdelivr.net/npm/@simonwep/pickr/dist/pickr.min.js"></script>
     <script src="popup.js" type="module"></script>

--- a/popup.js
+++ b/popup.js
@@ -53,6 +53,8 @@ const setImportExportMode = (mode) => {
     importExportActionButton.textContent = label
     if(mode === IMPORT_EXPORT_MODE.EXPORT){
         basicImportExportInput.focus()
+    }else if(mode === IMPORT_EXPORT_MODE.IMPORT){
+        basicImportExportInput.value = ''
     }
 }
 
@@ -105,13 +107,13 @@ document.querySelector('#exportButton').addEventListener('click', () => {
         let json = {}
         let color;
         for (let i = 0; i < colorScheme.length; i++) {
-            color = data[colorScheme[i]] ? data[colorScheme[i]] : colorDefaults[i]
+            color = result[colorScheme[i]] ? result[colorScheme[i]] : colorDefaults[i]
             json[colorScheme[i]] = color
         }
         if(useBasicImportExport){
             setBasicImportExportVisibility(true)
             setImportExportMode(IMPORT_EXPORT_MODE.EXPORT)
-            basicImportExportInput.textContent = JSON.stringify(data, null, 2)
+            basicImportExportInput.textContent = JSON.stringify(result, null, 2)
         }else{
             json = new Blob([JSON.stringify(json, null, 2)], {
                 type: "application/json"

--- a/popup.js
+++ b/popup.js
@@ -1,6 +1,11 @@
 const colorScheme = ["primaryColor", "secondaryColor", "tertiaryColor", "backgroundColor", "surfaceColor", "surfaceColorHover", "defaultWhite"]
 const colorDefaults = ["#9FC0A2", "#f5c276", "#d36d6d", "#2B343B", "#3F474D", "#4e565c", "#F2F5F3"]
 const styleTernary = 'document.documentElement.setAttribute("style", (document.documentElement.getAttribute("style") ? document.documentElement.getAttribute("style") : "") + "--'
+const basicImportExportContainer = document.getElementById('basicImportExportContainer')
+const basicImportExportInput = document.getElementById('basicImportExport')
+const importExportActionButton = document.getElementById('importExportAction')
+const useBasicImportExport = navigator.userAgent.indexOf("Firefox") !== -1
+
 
 
 var fileSelector = document.createElement('input');
@@ -12,22 +17,59 @@ fileSelector.onchange = function () {
 
     reader.onload = function (e) {
         console.log(e.target.result)
-        let json = JSON.parse(e.target.result)
-        console.log(json["primaryColor"])
-        let schemeCode, scheme, color
-        for (let i = 0; i < colorScheme.length; i++) {
-            scheme = colorScheme[i]
-            color = json[colorScheme[i]]
-            schemeCode = styleTernary + scheme + ': ' + color + ' !important;")'
-            tabScript(schemeCode);
-
-            chrome.storage.sync.set({
-                [scheme]: color
-            });
-        }
-        location.reload()
+        importScheme(e.target.result)
     };
     reader.readAsText(file)
+}
+
+const IMPORT_EXPORT_MODE = Object.freeze({
+    IMPORT: 'import',
+    EXPORT: 'export'
+})
+
+let importExportMode = null
+
+/**
+ * Set basic import/export container visibility
+ * @param {boolean} isVisible 
+ * @returns 
+ */
+const setBasicImportExportVisibility = (isVisible) => basicImportExportContainer.style.display = isVisible ? 'block' : 'none'
+/**
+ * Toggle visiblity of the basic import/export container
+ */
+const toggleBasicImportExport = () => {
+    const isHidden = basicImportExportContainer.style.display === 'none'
+    setBasicImportExportVisibility(!isHidden)
+}
+
+/**
+ * Set the import export color mode
+ * @param {'import' | 'export'} mode 
+ */
+const setImportExportMode = (mode) => {
+    const label = mode === IMPORT_EXPORT_MODE.IMPORT ? 'Save' : "Close"
+    importExportMode = mode;
+    importExportActionButton.textContent = label
+    if(mode === IMPORT_EXPORT_MODE.EXPORT){
+        basicImportExportInput.focus()
+    }
+}
+
+const importScheme = (data) => {
+    let json = JSON.parse(data)
+    console.log(json["primaryColor"])
+    let schemeCode, scheme, color
+    for (let i = 0; i < colorScheme.length; i++) {
+        scheme = colorScheme[i]
+        color = json[colorScheme[i]]
+        schemeCode = styleTernary + scheme + ': ' + color + ' !important;")'
+        tabScript(schemeCode);
+        chrome.storage.sync.set({
+            [scheme]: color
+        });
+    }
+    location.reload()
 }
 
 
@@ -39,29 +81,46 @@ document.querySelector('#resetButton').addEventListener('click', () => {
     chrome.storage.sync.clear()
     tabScript('window.location.reload();');
 })
-
 document.querySelector('#importButton').addEventListener('click', () => {
-    fileSelector.click()
+    if(useBasicImportExport){
+        setBasicImportExportVisibility(true)
+        setImportExportMode(IMPORT_EXPORT_MODE.IMPORT)
+    }else{
+        fileSelector.click()
+    }
     return false
 })
 
+importExportActionButton.addEventListener('click', () => {
+    if(importExportMode === 'import'){
+        importScheme(basicImportExportInput.value.trim())
+    }else{
+        setBasicImportExportVisibility(false)
+        setImportExportMode(null)
+    }
+})
+
 document.querySelector('#exportButton').addEventListener('click', () => {
-    chrome.storage.sync.get(null, function (result) {
+    chrome.storage.sync.get(null, function(result){
         let json = {}
         let color;
         for (let i = 0; i < colorScheme.length; i++) {
-            color = result[colorScheme[i]] ? result[colorScheme[i]] : colorDefaults[i]
+            color = data[colorScheme[i]] ? data[colorScheme[i]] : colorDefaults[i]
             json[colorScheme[i]] = color
         }
-        console.log(json)
-        json = new Blob([JSON.stringify(json, null, 2)], {
-            type: "application/json"
-        });
-        let url = URL.createObjectURL(json);
-        chrome.downloads.download({
-            url: url // The object URL can be used as download URL
-        });
-        console.log("Exported.")
+        if(useBasicImportExport){
+            setBasicImportExportVisibility(true)
+            setImportExportMode(IMPORT_EXPORT_MODE.EXPORT)
+            basicImportExportInput.textContent = JSON.stringify(data, null, 2)
+        }else{
+            json = new Blob([JSON.stringify(json, null, 2)], {
+                type: "application/json"
+            });
+            let url = URL.createObjectURL(json);
+            chrome.downloads.download({
+                url: url // The object URL can be used as download URL
+            });
+        }
     });
 })
 
@@ -114,8 +173,4 @@ function tabScript(code) {
                 code: code
             });
     });
-}
-
-if (navigator.userAgent.indexOf("Firefox") !== -1) {
-    document.getElementById('buttonRow').style.display = 'none';
 }

--- a/popupStyles.css
+++ b/popupStyles.css
@@ -143,3 +143,14 @@ input[type="color"]::-webkit-color-swatch {
     box-shadow: none !important;
     transform: scale(.9) !important;
 }
+
+#basicImportExportContainer {
+    margin: 8px 0;
+}
+#basicImportExport{
+    width: 100%;
+    background-color: #4b5b67;
+    color: #fff;
+    border: 1px solid #607585;
+    border-radius: 4px;
+}


### PR DESCRIPTION
Hello! We spoke on Reddit. 

The experience is a little poor, but the functionality is now there for Firefox. It could probably benefit from a clean up in the UI, but I think this is a good first step. 

**Test plan: Chrome**
1. Open popup
2. Click Export
3. Export your theme
4. Should use original file selector and export correctly
5. Click Import
6. Re-import the theme you just exported
7. Should use original file selector should import correctly

**Test plan: Firefox**
1. Open popup
2. Click Export
3. A text area should appear with the JSON contents for your theme
4. Copy the contents of the text area
5. Click import
6. Text area should clear, ready for pasting your theme
7. Paste your theme
8. Make a tweak to the primary colour
9. Click the save button at the bottom
10. Your theme should correctly update