### PR TITLE
Fixes background of rating range input

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1195,7 +1195,7 @@ a.button.button-metal:hover {
     box-shadow: none !important;
 }
 
-.game-setup .range input {
+.game-setup .range input, .game-setup .rating-range input{
     background: none !important;
 }
 


### PR DESCRIPTION
Presently, the rating range input has a background color of `--backgroundColor`.  
<img width="300" src="https://user-images.githubusercontent.com/10794178/118760563-a51ee980-b890-11eb-8948-82c784018e52.png">


This fixes that.