### PR TITLE
fixed eval bar on puzzle pages

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1450,6 +1450,33 @@ main.page-small {
     font-size: 1.5em !important;
 }
 
+/* for evaluation bar */
+
+@media (min-width: 1260px) {
+    .puzzle {
+        grid-template-columns: minmax(230px, 20vw) 2vmin minmax(calc(70vmin * var(--board-scale)),
+                calc(
+                    100vh * var(--board-scale) -
+                    calc(
+                        var(--site-header-height) + var(--site-header-margin)
+                    ) 
+                    - 3rem
+                )
+            ) 80px minmax(240px, 400px);
+    }
+    .puzzle-play:not(.gauge-on) .puzzle__tools {
+        transform: translateX(-63px);
+    }
+
+    .puzzle-play:not(.gauge-on) .puzzle__controls {
+        transform: translateX(-63px);
+    }
+    .puzzle__tools,
+    .puzzle__controls {
+        transition: transform 300ms ease-in-out;
+    }
+}
+
 /* Centering game board in puzzle storm */
 .storm--play {
     justify-content: center;


### PR DESCRIPTION
Closes #48 

<img width="600" src="https://user-images.githubusercontent.com/10794178/118938558-6cecd900-b96c-11eb-8b57-5d0229f0031d.png" >

Do note that this fixes the evaluation bar for screen sizes bigger than 1260px(width). The reason for that is because the extension presently disables the evaluation bar for screen sizes smaller than 1260px, and I wasn't sure if I should change that. 

Do let me know what you guys think.