### PR TITLE
Added padding to the analysis wiki sidebar

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2273,6 +2273,10 @@ a.context-streamer:hover {
     border: 0 !important;
 }
 
+.analyse__side .analyse__wiki {
+    padding: 0.5em 1em 0 1em;
+}
+
 .analyse__tools,
 #analyse-cm,
 #acpl-chart-loader {


### PR DESCRIPTION
Looks like this currently: 
![image](https://user-images.githubusercontent.com/6898931/136636887-569e46d7-a6d4-46a1-928b-9cbfd38abe2d.png)

With 1em left padding: 
![image](https://user-images.githubusercontent.com/6898931/136636910-ad9aa34c-5b3b-4585-b90f-37916bca3dea.png)

Also works for smaller screens:
**Before**: 
![image](https://user-images.githubusercontent.com/6898931/136636923-aa6eec7c-3efd-4b02-9e2e-e1ff1a4898fe.png)


**After**: 
![image](https://user-images.githubusercontent.com/6898931/136636948-f61378b3-f454-4ed2-a8b3-29d7f60c0198.png)