### PR TITLE
Moved user-select blocking to mobile only

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -64,12 +64,17 @@
 
 :root {
     -webkit-tap-highlight-color: transparent;
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
+    -webkit-touch-callout: none;   
+}
+
+@media only screen and (max-width: 768px) {
+    :root {
+        -webkit-user-select: none;
+        -khtml-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+    }
 }
 
 html {


### PR DESCRIPTION
Attempting to fix the blocking of user selection of text on desktop lichess. 

The original commit (a6539af0711668020d22debef8c6a6ac77837593) that removed this capability claimed to be a mobile fix and if this is the case I have nested the blocking to screens under 768px.

Issue here: https://github.com/prettierlichess/prettierlichess/issues/91

Why does this matter? This user-select: none stops users from coping test from chat windows, PGNs from studies and analysis boards and other things. Currently it requires a user to open up browser inspect tools and pull the PGN from there.