### PR TITLE
Fix overlay issue

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1396,7 +1396,6 @@ g[stroke="#888"] {
     align-items: center !important;
     justify-content: center !important;
     background: var(--surfaceColor) !important;
-    backdrop-filter: blur(16px) !important;
     border-radius: var(--borderRadius) !important;
     border: 2px solid var(--surfaceColorHover);
     padding: 40px 0 !important;


### PR DESCRIPTION
Fixes #93 

The backdrop filter caused `position: fixed` to be relative to the parent, instead of the viewport. Removing it fixes the issue. 

See [Why does applying a CSS-Filter on the parent break the child positioning](https://stackoverflow.com/questions/52937708/why-does-applying-a-css-filter-on-the-parent-break-the-child-positioning)