### PR TITLE
Add little padding for puzzle storm end statistics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "prettierlichess",
       "version": "1.0.0",
       "dependencies": {
         "@simonwep/pickr": "^1.8.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "prettierlichess",
       "version": "1.0.0",
       "dependencies": {
         "@simonwep/pickr": "^1.8.2"

--- a/src/styles.css
+++ b/src/styles.css
@@ -1968,6 +1968,10 @@ button.rematch-decline::before {
     font-size: 1.5em !important;
 }
 
+.storm--end__stats th {
+    padding: 10px;
+}
+
 /* Centering game board in puzzle storm and puzzle racer*/
 @media (min-width: 799px) {
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1969,7 +1969,7 @@ button.rematch-decline::before {
 }
 
 .storm--end__stats th {
-    padding: 10px;
+    padding-left: 10px !important;
 }
 
 /* Centering game board in puzzle storm and puzzle racer*/


### PR DESCRIPTION
My pull request adds little padding for text in puzzle storm end stats: 
![photo](https://user-images.githubusercontent.com/55882206/173207686-71a6b948-f599-4567-8a43-eaa9056a0476.png)
