### PR TITLE
Fix styling bug with player ratings hidden (107)

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1230,14 +1230,21 @@ main.lobby {
 	backdrop-filter: blur(16px) !important;
 }
 
+.lobby__wide-winners {
+	/* Used for when player ratings are hidden. Default lichess takes up more grid spaces to cover empty space - we don't want to. */
+	grid-area: winner !important;
+}
+
 .lobby__leaderboard,
-.lobby__winners {
+.lobby__winners,
+.lobby__wide-winners {
 	margin-top: 20px !important;
 	height: calc(100% - 40px) !important;
 }
 
 .lobby__leaderboard .lobby__box__content,
-.lobby__winners .lobby__box__content {
+.lobby__winners .lobby__box__content,
+.lobby__wide-winners .lobby__box__content {
 	overflow: hidden !important;
 }
 


### PR DESCRIPTION
Fixes bug #107.

The bug occurs when you have "Display -> Show player ratings" set to "No". This is because that setting hides the leaderboard and lichess (using the `lobby__wide-winners` class) extends the winners table to cover the space previously used for the leaderboard. 

Since prettier lichess sets the daily puzzle between the leaderboard and winners table there was some overlap. 

To fix it I have simply disabled this styling and allowed the empty space to exist. Let me know if you can think of a better solution :smile:.

Before PR:
![image](https://user-images.githubusercontent.com/12159487/193881838-696cba7d-ebba-45b6-8895-5e14de0cf882.png)

After PR:
![image](https://user-images.githubusercontent.com/12159487/193882013-020150c3-86d6-4be2-92bb-52768dc06c5d.png)