### PR TITLE
Mock Chrome API to test popup with http server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,17 @@ npm run watch
 After you have made your changes, check that the feature you have implemented works by navigating to the changed lichess page.
 If possible, feel free to test for both Firefox and Chrome. If this is not possible, please write in your PR on which platform you tested.
 
+## Testing the popup
+
+It is possible to run the popup on a local http server as a stand-alone website, making it easier to edit and test. The functionality for this is implemented in the `/testing` folder. There you will find a script that can start the http server. This requires a built version of the extension in the `/dist` folder. Then the script can be started with
+
+```
+npm run popup:run --port=PORT
+```
+
+on the port `PORT` (default 8000).
+There is also a mock script that is passed to the server to mock all Chrome API calls and sustain the functionality of the popup.
+
 ## Linting
 
 ### General

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "copy-webpack-plugin": "^10.0.0",
         "husky": "^8.0.1",
         "lint-staged": "^13.0.3",
+        "mime": "^3.0.0",
         "prettier": "2.7.1",
         "web-ext": "^7.3.1",
         "webpack": "^5.64.1",
@@ -4966,6 +4967,18 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -11481,6 +11494,12 @@
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
       }
+    },
+    "mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true
     },
     "mime-db": {
       "version": "1.51.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "copy-webpack-plugin": "^10.0.0",
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
+    "mime": "^3.0.0",
     "prettier": "2.7.1",
     "web-ext": "^7.3.1",
     "webpack": "^5.64.1",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "build": "npx webpack",
     "watch": "npx webpack -w",
-    "format:fix": "npx prettier --write --ignore-unknown src/**.{css,js,ts,html} *.{md,js}",
-    "format:check": "npx prettier --check --ignore-unknown src/**.{css,js,ts,html} *.{md,js}",
+    "popup:run": "cd dist && node ../testing/popupServer.js",
+    "format:fix": "npx prettier --write --ignore-unknown *.{css,js,ts,html,md} src/**/**.{css,js,ts,html,md} testing/**/**.{css,js,ts,html,md}",
+    "format:check": "npx prettier --check --ignore-unknown *.{css,js,ts,html,md} src/**/**.{css,js,ts,html,md} testing/**/**.{css,js,ts,html,md}",
     "prepare": "husky install"
   },
   "repository": {

--- a/testing/popupMock.js
+++ b/testing/popupMock.js
@@ -1,0 +1,66 @@
+// All Chrome-API functions are replaced.
+// This code is added to the beginning of popup.js when an http server is started.
+
+const conversions = {
+	true: true,
+	false: false,
+};
+const chrome = {
+	storage: {
+		sync: {
+			// The synced storage is mocked with localStorage
+			get: function (request, caller) {
+				// This conversion is necessary because synced can store all
+				// data types and localStorage can only store strings.
+				let convertedLocalStorage = {};
+
+				for (let key in localStorage) {
+					let value = localStorage[key];
+
+					if (value in conversions) {
+						value = conversions[value];
+					}
+					convertedLocalStorage[key] = value;
+				}
+				caller(convertedLocalStorage);
+			},
+			set: async function (items) {
+				for (let item in items) {
+					await localStorage.setItem(item, items[item]);
+				}
+			},
+			clear: async function () {
+				await localStorage.clear();
+			},
+		},
+	},
+	// The downloads-API is simulated with a HTML element
+	downloads: {
+		download: function (options) {
+			let link = document.createElement('a');
+			link.setAttribute('download', options['filename']);
+			link.href = options['url'];
+			link.click();
+		},
+	},
+	// The tab functions are not simulated but still replaced to avoid errors
+	tabs: {
+		query: function (properties, caller) {
+			caller([
+				{id: 0, url: 'https://www.lichess.org'},
+				{id: 1, url: 'https://www.lichess.org'},
+				{id: 2, url: undefined},
+			]);
+			console.log(
+				`[Mock] chrome.tabs.query(${JSON.stringify(properties)})`
+			);
+		},
+		executeScript: function (id, properties) {
+			console.log(
+				`[Mock] chrome.tabs.executeScript(${JSON.stringify(
+					id
+				)}, ${JSON.stringify(properties)})`
+			);
+		},
+	},
+};

--- a/testing/popupServer.js
+++ b/testing/popupServer.js
@@ -1,0 +1,62 @@
+const http = require('http');
+const filesystem = require('fs');
+const mime = require('mime');
+
+let popupMockContent;
+
+// Reading the mock code for injection
+filesystem.readFile(__dirname + '/popupMock.js', function (error, content) {
+	if (!error) {
+		popupMockContent = content;
+	} else {
+		throw error;
+	}
+});
+
+function timestamp() {
+	const x = new Date();
+	return x.toLocaleTimeString();
+}
+
+function requestHandler(request, response) {
+	let filePath;
+
+	if (request.url === '/') {
+		filePath = './popup.html';
+	} else {
+		filePath = './' + request.url;
+	}
+	const mimeType = mime.getType(filePath);
+
+	filesystem.readFile(filePath, function (error, content) {
+		let statusCode;
+
+		if (error) {
+			statusCode = error.code === 'ENOENT' ? 404 : 500;
+			response.writeHead(statusCode);
+			response.end();
+		} else {
+			// If the requested script is the popup script, the mock gets injected
+			if (request.url === '/popup.js') {
+				content = popupMockContent + content;
+				console.log(
+					`[127.0.0.1:${port}] - [${timestamp()}] Injected mock data`
+				);
+			}
+			statusCode = 200;
+			response.writeHead(200, {'Content-Type': mimeType});
+			response.write(content, 'utf-8');
+			response.end();
+		}
+		console.log(
+			`[127.0.0.1:${port}] - [${timestamp()}] "GET ${
+				request.url
+			}" ${statusCode}`
+		);
+	});
+}
+
+const port = process.env.npm_config_port ? process.env.npm_config_port : 8000;
+
+http.createServer(requestHandler).listen(port);
+console.log(`Server running at http://localhost:${port}/\n`);


### PR DESCRIPTION
This PR adds the functionality to also open the pop-up as its own web page. This makes it easier to edit, debug and test (possibly also automated) the pop-up. To be able to open the popup as a web page, it is necessary that all Chrome API calls are replaced.

Steps:
- [x] Create Mocker script
- [x] Create Http Server Script
- [x] Create command to serve popup on `localhost`
- [x] Write documentation