### PR TITLE
Fix layout with feed

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -161,7 +161,8 @@ main.lobby {
 		'app tv tv side'
 		'table blog blog support'
 		'leader puzzle puzzle winner'
-		'. tours tours .'
+		'feed puzzle puzzle .'
+		'feed tours tours .'
 		'. simuls simuls .'
 		'. about about .';
 	grid-template-columns: minmax(400px, 1fr) 1fr 1fr minmax(400px, 1fr);

--- a/src/styles.css
+++ b/src/styles.css
@@ -161,6 +161,7 @@ body,
 .lobby__blog .post,
 .lobby__blog .post time,
 .lobby__counters a,
+.lobby__feed,
 .subnav a,
 .mini-game,
 .mini-game:hover,
@@ -491,6 +492,7 @@ group.radio label,
 .mini-game__player,
 .tabs-horiz,
 .lobby__counters,
+.lobby__feed,
 .lobby__streams .stream,
 .timeline,
 .lobby__about a,
@@ -1281,6 +1283,14 @@ signal > i {
 .lobby__app__content {
 	border-radius: 0 !important;
 	background: none !important;
+}
+
+.lobby__feed {
+	background: var(--surfaceColor) !important;
+	justify-content: center !important;
+	border: 1px solid var(--surfaceColorHover);
+	padding: 20px 0 !important;
+	width: 100% !important;
 }
 
 .lpools {
@@ -4942,7 +4952,8 @@ body .glowing {
 			'winner  tours   tours'
 			'table table table'
 			'support blog    blog '
-			'simuls   simuls  simuls'
+			'feed    feed    feed'
+			'. simuls  simuls'
 			'. about about' !important;
 	}
 
@@ -5403,6 +5414,7 @@ body .glowing {
 			'tours'
 			'simuls'
 			'support'
+			'feed'
 			'about'
 			'.' !important;
 		grid-template-columns: 100% !important;


### PR DESCRIPTION
The feed that was recently added to the lichess homepage does not have an associated styling in Prettier, which was causing issues with the layout (compressing the rest of the grid)

![lichess-prettier-before-fullscreen-1](https://github.com/prettierlichess/prettierlichess/assets/60866462/ea9e9d47-dc3e-4aaa-a01b-4cd9e5f255a0)
![lichess-prettier-before-fullscreen-2](https://github.com/prettierlichess/prettierlichess/assets/60866462/e5133d93-6d51-4637-8c23-7a5fd7fe89f3)

This proposed change will incorporate the feed into the grid template area, so that it appears in the column underneath the leaderboard in full screen view and will take up an entire row in a resized window view.

![lichess-prettier-after-fullscreen](https://github.com/prettierlichess/prettierlichess/assets/60866462/61cc9a36-1eca-4055-8a4e-ea291fc83e24)
![lichess-prettier-after-halfscreen](https://github.com/prettierlichess/prettierlichess/assets/60866462/8490f698-b827-4a25-b2a1-4d6acf4f3231)

