### PR TITLE
Hide .lobby__feed from prettierlichess views

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -5463,3 +5463,7 @@ body .glowing {
 		visibility: hidden !important;
 	}
 }
+
+.lobby__feed {
+	display: none !important;
+}


### PR DESCRIPTION
New lobby__feed element breaks prettierlichess layouts completely. As a temporary countermeasure before layouts can be updated to account for added space, I hid lobby__feed completely to restore prior layout

Resolves #195 #198