### PR TITLE
fix: homepage, header, analysis, studies

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -161,7 +161,8 @@ main.lobby {
 		'app tv tv side'
 		'table blog blog support'
 		'leader puzzle puzzle winner'
-		'. tours tours .'
+		'feed puzzle puzzle .'
+		'feed tours tours .'
 		'. simuls simuls .'
 		'. about about .';
 	grid-template-columns: minmax(400px, 1fr) 1fr 1fr minmax(400px, 1fr);

--- a/src/styles.css
+++ b/src/styles.css
@@ -286,6 +286,11 @@ body {
 	background: var(--backgroundColor) !important;
 }
 
+body>header {
+	border: none !important;
+	background-image: none !important;
+}
+
 h1,
 h2,
 h3,

--- a/src/styles.css
+++ b/src/styles.css
@@ -286,7 +286,7 @@ body {
 	background: var(--backgroundColor) !important;
 }
 
-body>header {
+body > header {
 	border: none !important;
 	background-image: none !important;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -2709,6 +2709,14 @@ a.context-streamer:hover {
 	--meta-height: minmax(auto, 300px) !important;
 }
 
+#main-wrap {
+	margin-top: calc(
+		var(--site-header-height) +
+		var(--site-header-margin) +
+		var(--sticky-gap) + 20px
+	) !important;
+}
+
 @media (min-width: 1261px) {
 	#main-wrap .analyse:not(main.has-relay-tour) {
 		grid-template-columns:

--- a/src/styles.css
+++ b/src/styles.css
@@ -2707,14 +2707,7 @@ a.context-streamer:hover {
 	position: relative !important;
 	justify-content: center !important;
 	--meta-height: minmax(auto, 300px) !important;
-}
-
-#main-wrap {
-	margin-top: calc(
-		var(--site-header-height) +
-		var(--site-header-margin) +
-		var(--sticky-gap) + 20px
-	) !important;
+	margin-top: 20px !important;
 }
 
 @media (min-width: 1261px) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -3059,6 +3059,10 @@ a.context-streamer:hover {
 	color: var(--defaultWhite) !important;
 }
 
+.analyse__underboard {
+	margin-top: calc(var(--block-gap) + 0.5em) !important;
+}
+
 /* Analysis Graph */
 
 #acpl-chart,
@@ -5421,6 +5425,7 @@ body .glowing {
 			'tours'
 			'simuls'
 			'support'
+			'feed'
 			'about'
 			'.' !important;
 		grid-template-columns: 100% !important;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1242,7 +1242,7 @@ signal > i {
 /* Homepage */
 
 #main-wrap {
-	--main-max-width: 1500px !important;
+	/* --main-max-width: 1300px !important; */
 	justify-items: center !important;
 }
 
@@ -4402,7 +4402,7 @@ iframe.analyse {
 	background: none !important;
 	border: none !important;
 	justify-self: center !important;
-	margin-right: 70px !important;
+	/* margin-right: 70px !important; */
 }
 
 .blog .meta-headline {

--- a/src/styles.css
+++ b/src/styles.css
@@ -161,6 +161,7 @@ body,
 .lobby__blog .post,
 .lobby__blog .post time,
 .lobby__counters a,
+.lobby__feed,
 .subnav a,
 .mini-game,
 .mini-game:hover,
@@ -1281,6 +1282,14 @@ signal > i {
 .lobby__app__content {
 	border-radius: 0 !important;
 	background: none !important;
+}
+
+.lobby__feed {
+	background: var(--surfaceColor) !important;
+	justify-content: center !important;
+	border: 1px solid var(--surfaceColorHover);
+	padding: 20px 0 !important;
+	width: 100% !important;
 }
 
 .lpools {
@@ -4942,7 +4951,8 @@ body .glowing {
 			'winner  tours   tours'
 			'table table table'
 			'support blog    blog '
-			'simuls   simuls  simuls'
+			'feed    feed    feed'
+			'. simuls  simuls'
 			'. about about' !important;
 	}
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -3463,6 +3463,7 @@ a.analyse {
 	margin-top: 0 !important;
 	margin-right: 5px !important;
 	backdrop-filter: blur(16px) !important;
+	width: 100% !important;
 }
 
 .studies .study {

--- a/src/styles.css
+++ b/src/styles.css
@@ -2707,6 +2707,9 @@ a.context-streamer:hover {
 	position: relative !important;
 	justify-content: center !important;
 	--meta-height: minmax(auto, 300px) !important;
+}
+
+.analyse:not(.has-players) {
 	margin-top: 20px !important;
 }
 
@@ -2725,10 +2728,6 @@ a.context-streamer:hover {
 			)
 			80px minmax(240px, 400px) !important;
 	}
-}
-
-.analyse.has-players {
-	margin-top: 18px !important;
 }
 
 .analyse__side .mselect {

--- a/src/styles.css
+++ b/src/styles.css
@@ -2777,7 +2777,7 @@ a.context-streamer:hover {
 	#main-wrap .analyse__controls,
 	#main-wrap .analyse .pocket {
 		position: relative !important;
-		left: calc(-80px + 1vmin) !important;
+		left: calc(-80px + 2vmin) !important;
 		transition: left 0.3s ease-in-out !important;
 	}
 


### PR DESCRIPTION
Rolls in fixes from PR#196, and also includes:

- fixes header border and background
- fixes opponent time+captured pieces being covered by header in analysis mode
- fixes player time not having padding before understudy box in analysis mode
- fixes top margin in studies
- fixes header color and border
- fixes blog article layout
- fixes tv sidebar event alignment
- fixes gap between board and moves in studies on full width layout