### PR TITLE
Fix top bar for high screen resolutions

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -892,9 +892,6 @@ square.selected {
 	width: 100vw !important;
 	align-items: center !important;
 	justify-content: center !important;
-	margin-left: 0 15vw !important;
-	left: 0 !important;
-	right: 0 !important;
 	max-width: 1800px !important;
 }
 


### PR DESCRIPTION
Should fix #205

With the changes lichess made to the top bar, our rules for making sure the bar is centred no longer work. With smaller resolutions, the bar will still end up in the right place by accident, because there is less space. But with `justify-content` already in place, we can simply remove the other rules.