### PR TITLE
Fix placement of top bar and main wrap for mobile view

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -5105,7 +5105,6 @@ body .glowing {
 	}
 
 	body #main-wrap {
-		margin: 0 !important;
 		padding: 0 !important;
 		overflow-x: hidden !important;
 	}
@@ -5399,11 +5398,9 @@ body .glowing {
 
 	#main-wrap {
 		width: 100% !important;
-		margin: 0 !important;
 		grid-template-columns:
 			var(--main-margin) 1fr minmax(auto, var(--main-max-width))
 			1fr var(--main-margin) !important;
-		margin-top: var(--site-header-margin) !important;
 	}
 
 	#topnav {


### PR DESCRIPTION
Closes #206 

The removal of the margin rules for mobile view results in the correct placement of the board below the top bar:
![grafik](https://github.com/prettierlichess/prettierlichess/assets/81773954/c36ed1bf-912d-4e95-9086-e83e2d746e56)
