### PR TITLE
Updated manifest for v3 and fixed the issue of default board not rendering

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,14 +1,14 @@
 {
 	"name": "Prettier Lichess",
 	"version": "3.13.0",
-	"manifest_version": 2,
+	"manifest_version": 3,
 	"description": "Lichess, but prettier.",
 	"icons": {
 		"128": "icon_128.png"
 	},
 	"content_scripts": [
 		{
-			"matches": ["*://lichess.org/*"],
+			"matches": ["*://*.lichess.org/*"],
 			"exclude_matches": ["*://lichess.org/api*"],
 			"run_at": "document_start",
 			"css": ["styles.css"],
@@ -22,7 +22,7 @@
 			"all_frames": true
 		}
 	],
-	"browser_action": {
+	"action": {
 		"default_popup": "popup.html"
 	},
 	"permissions": [
@@ -30,19 +30,18 @@
 		"storage",
 		"declarativeContent",
 		"downloads",
-		"*://lichess.org/*"
+		"scripting"
 	],
 	"background": {
-		"scripts": ["background.js"],
-		"persistent": false
+		"service_worker": "background.js"
 	},
-	"content_security_policy": "script-src 'self'; object-src 'self';",
-	"web_accessible_resources": [
-		"styles.css",
-		"fonts/*",
-		"pieces/*",
-		"masks/*"
-	],
+	"content_security_policy": {
+  "extension_pages": "script-src 'self'; object-src 'self';"
+},  "web_accessible_resources": [
+    {
+      "resources": [ "styles.css", "fonts/*", "pieces/*", "masks/*" ],
+      "matches": [ "*://*.lichess.org/*" ]
+    }],
 	"browser_specific_settings": {
 		"gecko": {
 			"id": "{8ad4bea8-ad8d-4e98-b434-a76065dee6cb}",

--- a/src/styles.css
+++ b/src/styles.css
@@ -548,7 +548,7 @@ cg-container cg-board square {
 }
  */
 
-cg-container cg-board::before {
+cg-container cg-board::after {
 	content: '' !important;
 	position: absolute !important;
 	left: 0 !important;
@@ -1652,6 +1652,7 @@ a.button.button-metal:hover {
 	white-space: initial !important;
 	display: -webkit-box !important;
 	-webkit-line-clamp: 2 !important;
+	line-clamp: 2 !important;
 	-webkit-box-orient: vertical !important;
 }
 


### PR DESCRIPTION
Hi! I love the extension but the "Don't use custom board colors" setting was a problem, as the default board would never render:
<img src="https://github.com/user-attachments/assets/16824e33-048b-41ed-a747-db495a40b2f4" height="360" width="560" ></a>
So I think I've fixed the issue as well as updated the code to be compatible with manifest v3. I've tested it on Chrome and didn't run into issues, but I haven't gotten to test it extensively on Firefox yet, although it seemed to be okay. The only thing is, I had to define background.js as a script as well as a service worker in the background field like so:

```
"background": {
   "service_worker": "background.js",
   "scripts": ["background.js"],
   "type": "module"
},
```

This is probably terrible practice but it was the fastest way I could test it on Firefox, so this is the main problem I want to mention. I did remove it from the manifest at the end.
Another thing I want to mention is that I changed the CSS pseudo-element belonging to `cg-container cg-board`  from `::before` to `::after`. It did not any side effects that I noticed and it was necessary to have the default board render correctly.